### PR TITLE
[fix]b-alertの中央寄せ(リファクタで消してた)

### DIFF
--- a/components/BulletinBoard.vue
+++ b/components/BulletinBoard.vue
@@ -192,5 +192,6 @@ export default {
     left: 0;
     bottom: 0;
     right: 0;
+    text-align: center;
   }
 </style>


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 -->
b-alertの中央寄せ(リファクタで消してた)

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
b-alertの中央寄せ(リファクタで消してた)

# 影響の恐れがある点
<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->